### PR TITLE
Fix read/write of WinDivertAddress fields from/to native memory

### DIFF
--- a/src/main/java/com/github/ffalcinelli/jdivert/WinDivert.java
+++ b/src/main/java/com/github/ffalcinelli/jdivert/WinDivert.java
@@ -198,6 +198,7 @@ public class WinDivert {
         Memory buffer = new Memory(bufsize);
         IntByReference recvLen = new IntByReference();
         dll.WinDivertRecv(handle, buffer, bufsize, address.getPointer(), recvLen);
+        address.read();
         throwExceptionOnGetLastError();
         byte[] raw = buffer.getByteArray(0, recvLen.getValue());
         return new Packet(raw, address);
@@ -270,12 +271,14 @@ public class WinDivert {
         if (recalculateChecksum) {
             packet.recalculateChecksum(options);
         }
+        WinDivertAddress address = packet.getWinDivertAddress();
         IntByReference sendLen = new IntByReference();
         byte[] raw = packet.getRaw();
         Memory buffer = new Memory(raw.length);
 
         buffer.write(0, raw, 0, raw.length);
-        dll.WinDivertSend(handle, buffer, raw.length, packet.getWinDivertAddress().getPointer(), sendLen);
+        address.write();
+        dll.WinDivertSend(handle, buffer, raw.length, address.getPointer(), sendLen);
         throwExceptionOnGetLastError();
         return sendLen.getValue();
     }


### PR DESCRIPTION
I noticed that the WinDivertAddress fields weren't set properly because the native memory of the JNA structure didn't get updated.

> Note that if you use the structure's pointer as a function argument, you are responsible for calling write() prior to the call and read() after the call.

\- https://java-native-access.github.io/jna/4.2.1/com/sun/jna/Structure.html#getPointer--



Unrelated:
I also noticed that WinDef.USHORT is used for the direction which has a size of 2 bytes but it originally is defined as UINT8 (uint8_t) with a size of 1 byte. Could this generally be a problem? I'm just interested because I don't know much about JNA.