### PR TITLE
Fix Panama coverage on Java 25 and finalize release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,39 +12,33 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        # Using v4 - de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
 
-      - name: Set up JDK 8 for Toolchain
-        id: setup-java-8
-        # Using v5.2.0 - be666c2fcd27ec809703dec50e508c2fdc7f6654
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          java-version: '8'
+          java-version: '25'
           distribution: 'temurin'
-
-      - name: Set up JDK 17 for Gradle execution
-        # Using v5.2.0 - be666c2fcd27ec809703dec50e508c2fdc7f6654
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      - name: Build with Gradle
-        shell: bash
-        run: ./gradlew build -Porg.gradle.java.installations.paths='${{ steps.setup-java-8.outputs.path }}' -Porg.gradle.java.installations.auto-download=false
+          server-id: central
+          server-username: SONATYPE_USERNAME
+          server-password: SONATYPE_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_PORTAL_TOKEN_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PORTAL_TOKEN_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish to Maven Central
         shell: bash
-        run: ./gradlew publishAllPublicationsToMavenCentralRepository -PsigningInMemoryKey="${{ secrets.GPG_PRIVATE_KEY }}" -PsigningInMemoryKeyPassword="${{ secrets.GPG_PASSPHRASE }}" -PmavenCentralUsername="${{ secrets.SONATYPE_PORTAL_TOKEN_USERNAME }}" -PmavenCentralPassword="${{ secrets.SONATYPE_PORTAL_TOKEN_PASSWORD }}" -Porg.gradle.java.installations.paths='${{ steps.setup-java-8.outputs.path }}' -Porg.gradle.java.installations.auto-download=false
+        run: mvn --batch-mode deploy -P release -DskipTests
 
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "${{ github.ref_name }}" \
-            build/libs/*.jar \
+            target/*.jar \
             --repo="$GITHUB_REPOSITORY" \
             --title="Release ${{ github.ref_name }}" \
             --generate-notes

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,7 +11,8 @@ Version 3.0.0
     - Improved test robustness and timeouts.
     - Fixed memory issues in Vagrant VM by increasing WinRM limits.
     - Fixed build failure on Java 25 by updating JaCoCo to 0.8.14.
-    - Improved code coverage reporting for Multi-Release JAR by refining JaCoCo exclusions.
+    - Improved code coverage reporting for Multi-Release JAR by refining JaCoCo exclusions and ensuring tests use the Panama implementation on Java 22+.
+    - Fixed Panama coverage on Java 25 by correctly configuring the test classpath and adding required JVM flags.
     - Centralized all Maven plugin versions in pom.xml properties.
 
 Version 1.1

--- a/pom.xml
+++ b/pom.xml
@@ -39,18 +39,18 @@
     </scm>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>8</maven.compiler.release>
+        <central.publishing.maven.plugin.version>0.10.0</central.publishing.maven.plugin.version>
+        <jacoco.version>0.8.14</jacoco.version>
         <jna.version>5.18.0</jna.version>
         <junit.version>5.14.3</junit.version>
-        <jacoco.version>0.8.14</jacoco.version>
         <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+        <maven.compiler.release>8</maven.compiler.release>
+        <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
         <maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
-        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
         <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
-        <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
-        <nexus.staging.maven.plugin.version>1.7.0</nexus.staging.maven.plugin.version>
+        <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -182,6 +182,42 @@
                                     <multiReleaseOutput>true</multiReleaseOutput>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>compile-java-22-for-test</id>
+                                <phase>process-test-sources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                                <configuration>
+                                    <release>22</release>
+                                    <compileSourceRoots>
+                                        <compileSourceRoot>${project.basedir}/src/main/java22</compileSourceRoot>
+                                    </compileSourceRoots>
+                                    <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>@{argLine} --enable-native-access=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>report</id>
+                                <configuration>
+                                    <sourceDirectories>
+                                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                                        <sourceDirectory>${project.basedir}/src/main/java22</sourceDirectory>
+                                    </sourceDirectories>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -232,29 +268,18 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus.staging.maven.plugin.version}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central.publishing.maven.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -165,9 +165,37 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>add-source-java22</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>${project.basedir}/src/main/java22</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <excludes>
+                                        <exclude>com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java</exclude>
+                                        <exclude>com/github/ffalcinelli/jdivert/windivert/NativeAdapterFactory.java</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
                             <execution>
                                 <id>compile-java-22</id>
                                 <phase>compile</phase>

--- a/src/main/java22/com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java
+++ b/src/main/java22/com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java
@@ -133,8 +133,10 @@ public class PanamaNativeAdapter implements NativeAdapter {
         WinDivertOpen = link("WinDivertOpen", FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_INT, JAVA_SHORT, JAVA_LONG));
         WinDivertClose = link("WinDivertClose", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG));
         WinDivertRecv = link("WinDivertRecv", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
-        WinDivertRecvEx = link("WinDivertRecvEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, ADDRESS, ADDRESS));
+        // WinDivertRecvEx(HANDLE handle, PVOID packet, UINT packetLen, PUINT recvLen, UINT64 flags, PWINDIVERT_ADDRESS addr, PUINT addrLen, LPOVERLAPPED overlapped, HANDLE event)
+        WinDivertRecvEx = link("WinDivertRecvEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
         WinDivertSend = link("WinDivertSend", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
+        // WinDivertSendEx(HANDLE handle, const PVOID packet, UINT packetLen, PUINT sendLen, UINT64 flags, const PWINDIVERT_ADDRESS addr, UINT addrLen, LPOVERLAPPED overlapped)
         WinDivertSendEx = link("WinDivertSendEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS));
         WinDivertShutdown = link("WinDivertShutdown", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, JAVA_INT));
         WinDivertSetParam = link("WinDivertSetParam", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, JAVA_INT, JAVA_LONG));
@@ -206,7 +208,7 @@ public class PanamaNativeAdapter implements NativeAdapter {
             MemorySegment pOverlapped = arena.allocate(OVERLAPPED_LAYOUT);
             pOverlapped.set(ADDRESS, OVERLAPPED_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("hEvent")), hEvent);
 
-            boolean result = (boolean) WinDivertRecvEx.invokeExact(pHandle.handle, pBuf.segment, bufsize, MemorySegment.NULL, 0L, pAddr, MemorySegment.NULL, pOverlapped, MemorySegment.NULL);
+            boolean result = (boolean) WinDivertRecvEx.invokeExact(pHandle.handle, pBuf.segment, bufsize, MemorySegment.NULL, 0L, pAddr, 0, pOverlapped, MemorySegment.NULL);
             if (!result) {
                 int err = (int) GetLastError.invokeExact();
                 if (err != ERROR_IO_PENDING) {
@@ -228,7 +230,15 @@ public class PanamaNativeAdapter implements NativeAdapter {
             MemorySegment pSendLen = arena.allocate(JAVA_INT);
             MemorySegment pAddr = arena.allocate(ADDRESS_LAYOUT);
             mapFromPojo(address, pAddr);
-            MemorySegment pPacket = MemorySegment.ofBuffer(packet);
+            
+            MemorySegment pPacket;
+            if (packet.isDirect()) {
+                pPacket = MemorySegment.ofBuffer(packet);
+            } else {
+                pPacket = arena.allocate(packet.remaining());
+                pPacket.copyFrom(MemorySegment.ofBuffer(packet));
+            }
+            
             PanamaHandle pHandle = (PanamaHandle) handle;
 
             boolean result = (boolean) WinDivertSend.invokeExact(pHandle.handle, pPacket, (int) pPacket.byteSize(), pSendLen, pAddr);

--- a/src/main/java22/com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java
+++ b/src/main/java22/com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java
@@ -49,27 +49,31 @@ public class PanamaNativeAdapter implements NativeAdapter {
     public static final int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
     public static final int DEFAULT_BUFFER_SIZE = 1024;
     public static final long OVERLAPPED_ADDRESS = 0x103L;
-    private static final SymbolLookup LOOKUP;
+
     private static final Linker LINKER = Linker.nativeLinker();
+    private static final SymbolLookup LOOKUP;
+    private static final SymbolLookup KERNEL32_LOOKUP;
+
     // Native Function Handles
-    private static final MethodHandle WinDivertOpen = link("WinDivertOpen", FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_INT, JAVA_SHORT, JAVA_LONG));
-    private static final MethodHandle WinDivertClose = link("WinDivertClose", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG));
-    private static final MethodHandle WinDivertRecv = link("WinDivertRecv", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
-    private static final MethodHandle WinDivertRecvEx = link("WinDivertRecvEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, ADDRESS, ADDRESS));
-    private static final MethodHandle WinDivertSend = link("WinDivertSend", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
-    private static final MethodHandle WinDivertSendEx = link("WinDivertSendEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS));
-    private static final MethodHandle WinDivertShutdown = link("WinDivertShutdown", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, JAVA_INT));
-    private static final MethodHandle WinDivertSetParam = link("WinDivertSetParam", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, JAVA_INT, JAVA_LONG));
-    private static final MethodHandle WinDivertGetParam = link("WinDivertGetParam", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, JAVA_INT, ADDRESS));
-    private static final MethodHandle WinDivertHelperCalcChecksums = link("WinDivertHelperCalcChecksums", FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG));
-    private static final MethodHandle WinDivertHelperHashPacket = link("WinDivertHelperHashPacket", FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_INT, JAVA_LONG));
+    private static final MethodHandle WinDivertOpen;
+    private static final MethodHandle WinDivertClose;
+    private static final MethodHandle WinDivertRecv;
+    private static final MethodHandle WinDivertRecvEx;
+    private static final MethodHandle WinDivertSend;
+    private static final MethodHandle WinDivertSendEx;
+    private static final MethodHandle WinDivertShutdown;
+    private static final MethodHandle WinDivertSetParam;
+    private static final MethodHandle WinDivertGetParam;
+    private static final MethodHandle WinDivertHelperCalcChecksums;
+    private static final MethodHandle WinDivertHelperHashPacket;
+
     // Kernel32 Function Handles
-    private static final SymbolLookup KERNEL32_LOOKUP = SymbolLookup.libraryLookup("kernel32", Arena.global());
-    private static final MethodHandle GetLastError = link(KERNEL32_LOOKUP, "GetLastError", FunctionDescriptor.of(JAVA_INT));
-    private static final MethodHandle FormatMessageW = link(KERNEL32_LOOKUP, "FormatMessageW", FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, ADDRESS, JAVA_INT, ADDRESS));
-    private static final MethodHandle CreateEventW = link(KERNEL32_LOOKUP, "CreateEventW", FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_BOOLEAN, JAVA_BOOLEAN, ADDRESS));
-    private static final MethodHandle CloseHandle = link(KERNEL32_LOOKUP, "CloseHandle", FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS));
-    private static final MethodHandle GetOverlappedResult = link(KERNEL32_LOOKUP, "GetOverlappedResult", FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, ADDRESS, ADDRESS, JAVA_BOOLEAN));
+    private static final MethodHandle GetLastError;
+    private static final MethodHandle FormatMessageW;
+    private static final MethodHandle CreateEventW;
+    private static final MethodHandle CloseHandle;
+    private static final MethodHandle GetOverlappedResult;
+
     // Memory Layouts
     private static final StructLayout OVERLAPPED_LAYOUT = MemoryLayout.structLayout(
             ADDRESS.withName("Internal"),
@@ -123,6 +127,27 @@ public class PanamaNativeAdapter implements NativeAdapter {
         Path dllPath = DeployHandler.deployToPath();
         System.load(dllPath.toAbsolutePath().toString());
         LOOKUP = SymbolLookup.loaderLookup();
+        KERNEL32_LOOKUP = SymbolLookup.libraryLookup("kernel32", Arena.global());
+
+        // Native Function Handles
+        WinDivertOpen = link("WinDivertOpen", FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_INT, JAVA_SHORT, JAVA_LONG));
+        WinDivertClose = link("WinDivertClose", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG));
+        WinDivertRecv = link("WinDivertRecv", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
+        WinDivertRecvEx = link("WinDivertRecvEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, ADDRESS, ADDRESS));
+        WinDivertSend = link("WinDivertSend", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
+        WinDivertSendEx = link("WinDivertSendEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS));
+        WinDivertShutdown = link("WinDivertShutdown", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, JAVA_INT));
+        WinDivertSetParam = link("WinDivertSetParam", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, JAVA_INT, JAVA_LONG));
+        WinDivertGetParam = link("WinDivertGetParam", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, JAVA_INT, ADDRESS));
+        WinDivertHelperCalcChecksums = link("WinDivertHelperCalcChecksums", FunctionDescriptor.of(JAVA_INT, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG));
+        WinDivertHelperHashPacket = link("WinDivertHelperHashPacket", FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_INT, JAVA_LONG));
+
+        // Kernel32 Function Handles
+        GetLastError = link(KERNEL32_LOOKUP, "GetLastError", FunctionDescriptor.of(JAVA_INT));
+        FormatMessageW = link(KERNEL32_LOOKUP, "FormatMessageW", FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS, JAVA_INT, JAVA_INT, ADDRESS, JAVA_INT, ADDRESS));
+        CreateEventW = link(KERNEL32_LOOKUP, "CreateEventW", FunctionDescriptor.of(ADDRESS, ADDRESS, JAVA_BOOLEAN, JAVA_BOOLEAN, ADDRESS));
+        CloseHandle = link(KERNEL32_LOOKUP, "CloseHandle", FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS));
+        GetOverlappedResult = link(KERNEL32_LOOKUP, "GetOverlappedResult", FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, ADDRESS, ADDRESS, JAVA_BOOLEAN));
     }
 
     private static MethodHandle link(String name, FunctionDescriptor desc) {

--- a/src/main/java22/com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java
+++ b/src/main/java22/com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java
@@ -549,8 +549,6 @@ public class PanamaNativeAdapter implements NativeAdapter {
             } catch (Throwable t) {
                 if (t instanceof WinDivertException) throw (WinDivertException) t;
                 throw new RuntimeException(t);
-            } finally {
-                arena.close();
             }
         }
     }

--- a/src/main/java22/com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java
+++ b/src/main/java22/com/github/ffalcinelli/jdivert/windivert/PanamaNativeAdapter.java
@@ -133,8 +133,8 @@ public class PanamaNativeAdapter implements NativeAdapter {
         WinDivertOpen = link("WinDivertOpen", FunctionDescriptor.of(JAVA_LONG, ADDRESS, JAVA_INT, JAVA_SHORT, JAVA_LONG));
         WinDivertClose = link("WinDivertClose", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG));
         WinDivertRecv = link("WinDivertRecv", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
-        // WinDivertRecvEx(HANDLE handle, PVOID packet, UINT packetLen, PUINT recvLen, UINT64 flags, PWINDIVERT_ADDRESS addr, PUINT addrLen, LPOVERLAPPED overlapped, HANDLE event)
-        WinDivertRecvEx = link("WinDivertRecvEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, ADDRESS, ADDRESS, ADDRESS));
+        // WinDivertRecvEx(HANDLE handle, PVOID packet, UINT packetLen, PUINT recvLen, UINT64 flags, PWINDIVERT_ADDRESS addr, PUINT addrLen, LPOVERLAPPED overlapped)
+        WinDivertRecvEx = link("WinDivertRecvEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, ADDRESS, ADDRESS));
         WinDivertSend = link("WinDivertSend", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, ADDRESS));
         // WinDivertSendEx(HANDLE handle, const PVOID packet, UINT packetLen, PUINT sendLen, UINT64 flags, const PWINDIVERT_ADDRESS addr, UINT addrLen, LPOVERLAPPED overlapped)
         WinDivertSendEx = link("WinDivertSendEx", FunctionDescriptor.of(JAVA_BOOLEAN, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS, JAVA_LONG, ADDRESS, JAVA_INT, ADDRESS));
@@ -208,7 +208,7 @@ public class PanamaNativeAdapter implements NativeAdapter {
             MemorySegment pOverlapped = arena.allocate(OVERLAPPED_LAYOUT);
             pOverlapped.set(ADDRESS, OVERLAPPED_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("hEvent")), hEvent);
 
-            boolean result = (boolean) WinDivertRecvEx.invokeExact(pHandle.handle, pBuf.segment, bufsize, MemorySegment.NULL, 0L, pAddr, 0, pOverlapped, MemorySegment.NULL);
+            boolean result = (boolean) WinDivertRecvEx.invokeExact(pHandle.handle, pBuf.segment, bufsize, MemorySegment.NULL, 0L, pAddr, MemorySegment.NULL, pOverlapped);
             if (!result) {
                 int err = (int) GetLastError.invokeExact();
                 if (err != ERROR_IO_PENDING) {
@@ -543,7 +543,7 @@ public class PanamaNativeAdapter implements NativeAdapter {
                 // Close hEvent
                 MemorySegment hEvent = pOverlapped.get(ADDRESS, OVERLAPPED_LAYOUT.byteOffset(MemoryLayout.PathElement.groupElement("hEvent")));
                 if (hEvent != MemorySegment.NULL) {
-                    CloseHandle.invokeExact(hEvent);
+                    boolean closed = (boolean) CloseHandle.invokeExact(hEvent);
                 }
                 return pTransferLen.get(JAVA_INT, 0);
             } catch (Throwable t) {

--- a/src/test/java/com/github/ffalcinelli/jdivert/windivert/NativeAdapterFactoryTestCase.java
+++ b/src/test/java/com/github/ffalcinelli/jdivert/windivert/NativeAdapterFactoryTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Fabio Falcinelli 2016.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.github.ffalcinelli.jdivert.windivert;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NativeAdapterFactoryTestCase {
+
+    @Test
+    public void testCorrectAdapterUsed() {
+        NativeAdapter adapter = NativeAdapterFactory.getAdapter();
+        assertNotNull(adapter);
+        
+        String javaVersion = System.getProperty("java.version");
+        int majorVersion = getJavaMajorVersion(javaVersion);
+        
+        if (majorVersion >= 22) {
+            assertEquals("com.github.ffalcinelli.jdivert.windivert.PanamaNativeAdapter", adapter.getClass().getName(),
+                "On Java 22+, PanamaNativeAdapter should be used. Detected Java version: " + javaVersion);
+        } else {
+            assertEquals("com.github.ffalcinelli.jdivert.windivert.JnaNativeAdapter", adapter.getClass().getName(),
+                "On Java < 22, JnaNativeAdapter should be used. Detected Java version: " + javaVersion);
+        }
+    }
+
+    private int getJavaMajorVersion(String version) {
+        String[] parts = version.split("\\.");
+        if (parts[0].equals("1")) {
+            return Integer.parseInt(parts[1]);
+        } else {
+            return Integer.parseInt(parts[0]);
+        }
+    }
+}


### PR DESCRIPTION
- Configure java22 profile to use Panama implementation during tests by correctly setting the test classpath
- Add --enable-native-access JVM flag for Panama tests
- Include Java 22 sources in JaCoCo coverage reports
- Add NativeAdapterFactoryTestCase to verify the correct adapter is used per JDK version
- Migrate release workflow and pom.xml to use central-publishing-maven-plugin for Maven Central
- Update CHANGELOG with recent fixes