### PR TITLE
Fix Javadoc generation failure on JDK 22+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
                 <version>${maven.javadoc.plugin.version}</version>
                 <configuration>
                     <outputDirectory>${project.basedir}/docs/api</outputDirectory>
+                    <sourcepath>${project.build.sourceDirectory}</sourcepath>
                     <release>${maven.compiler.release}</release>
                     <detectJavaApiLink>false</detectJavaApiLink>
                     <doclint>none</doclint>


### PR DESCRIPTION
- Explicitly set sourcepath to the base source directory (src/main/java)
- This prevents the javadoc plugin (targeting Java 8) from attempting to process Java 22 implementation classes (using records) when the java22 profile is active.